### PR TITLE
Revert "Don't smoke test benchmarks with debug logger"

### DIFF
--- a/test/SchedulersTests/src/test_benchmarks.jl
+++ b/test/SchedulersTests/src/test_benchmarks.jl
@@ -1,6 +1,5 @@
 module TestBenchmarks
 
-using Schedulers.Internal: Debug
 using SchedulersBenchmarks: clear, setup_smoke
 using Test
 
@@ -8,7 +7,6 @@ function test_smoke_test_benchmarks()
     try
         local suite
         @test (suite = setup_smoke()) isa Any
-        Debug.get_logger() === nothing || return
         @test run(suite) isa Any
     finally
         clear()


### PR DESCRIPTION
This reverts commit bf30a6a49cc58ae0a58573a3d8ec0db55372fc7b.